### PR TITLE
refactor: added method overloads to omit param "columnName"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var mapper = new MapperBuilder<Person>()
     .SetTableName("People")
     .AddMapping(person => person.FirstName, columnName: "Name")
     .AddMapping(person => person.LastName, columnName: "Surename")
-    .AddMapping(person => person.DateOfBirth, columnName: "Birthday")
+    .AddMapping(person => person.DateOfBirth) // in this case property's name is the same as table column's name
     .Build();
 var people = new List<Person>()
 { 
@@ -54,7 +54,7 @@ var mapper = new MapperBuilder<Person>()
     .SetTableName("People")
     .AddMapping(person => person.FirstName, columnName: "Name")
     .AddMapping(person => person.LastName, columnName: "Surename")
-    .AddMapping(person => person.DateOfBirth, columnName: "Birthday")
+    .AddMapping(person => person.DateOfBirth) // in this case property's name is the same as table column's name
     .Build();
 var people = new List<Person>()
 { 
@@ -82,7 +82,7 @@ var mapper = new MapperBuilder<Person>()
     .SetTableName("People")
     .AddMapping(person => person.FirstName, columnName: "Name")
     .AddMapping(person => person.LastName, columnName: "Surename")
-    .AddMapping(person => person.DateOfBirth, columnName: "Birthday")
+    .AddMapping(person => person.DateOfBirth) // in this case property's name is the same as table column's name
     .Build();
 var people = new List<Person>()
 { 

--- a/src/MsSqlHelpers.Tests/MsSqlQueryGeneratorTests.cs
+++ b/src/MsSqlHelpers.Tests/MsSqlQueryGeneratorTests.cs
@@ -27,8 +27,8 @@ namespace MsSqlHelpers.Tests
         {
             var mapper = new MapperBuilder<Person>()
                 .SetTableName(tableName)
-                .AddMapping(person => person.FirstName, columnName: nameof(Person.FirstName))
-                .AddMapping(person => person.LastName, columnName: nameof(Person.LastName))
+                .AddMapping(person => person.FirstName)
+                .AddMapping(person => person.LastName)
                 .AddMapping(person => person.DateOfBirth, columnName: "Birthday")
                 .Build();
             var people = new Faker<Person>()
@@ -96,8 +96,8 @@ namespace MsSqlHelpers.Tests
             var tableName = Guid.NewGuid().ToString();
             var mapper = new MapperBuilder<Person>()
                 .SetTableName(tableName)
-                .AddMapping(person => person.FirstName, columnName: nameof(Person.FirstName))
-                .AddMapping(person => person.LastName, columnName: nameof(Person.LastName))
+                .AddMapping(person => person.FirstName)
+                .AddMapping(person => person.LastName)
                 .AddMapping(person => person.DateOfBirth, columnName: "Birthday")
                 .Build();
 
@@ -112,8 +112,8 @@ namespace MsSqlHelpers.Tests
             var tableName = Guid.NewGuid().ToString();
             var mapper = new MapperBuilder<Person>()
                 .SetTableName(tableName)
-                .AddMapping(person => person.FirstName, columnName: nameof(Person.FirstName))
-                .AddMapping(person => person.LastName, columnName: nameof(Person.LastName))
+                .AddMapping(person => person.FirstName)
+                .AddMapping(person => person.LastName)
                 .AddMapping(person => person.DateOfBirth, columnName: "Birthday")
                 .Build();
             var people = new Faker<Person>()
@@ -137,8 +137,8 @@ namespace MsSqlHelpers.Tests
             var tableName = Guid.NewGuid().ToString();
             var mapper = new MapperBuilder<Person>()
                 .SetTableName(tableName)
-                .AddMapping(person => person.FirstName, columnName: nameof(Person.FirstName))
-                .AddMapping(person => person.LastName, columnName: nameof(Person.LastName))
+                .AddMapping(person => person.FirstName)
+                .AddMapping(person => person.LastName)
                 .AddMapping(person => person.DateOfBirth, columnName: "Birthday")
                 .Build();
             var people = new Faker<Person>()
@@ -162,7 +162,7 @@ namespace MsSqlHelpers.Tests
             var tableName = Guid.NewGuid().ToString();
             var mapper = new MapperBuilder<Person>()
                 .SetTableName(tableName)
-                .AddMapping(person => person.FirstName, columnName: nameof(Person.FirstName))
+                .AddMapping(person => person.FirstName)
                 .Build();
             var people = new Faker<Person>()
                 .RuleFor(person => person.FirstName, fakePerson => fakePerson.Person.FirstName)
@@ -179,8 +179,8 @@ namespace MsSqlHelpers.Tests
             var tableName = Guid.NewGuid().ToString();
             var mapper = new MapperBuilder<Person>()
                 .SetTableName(tableName)
-                .AddMapping(person => person.FirstName, columnName: nameof(Person.FirstName))
-                .AddMapping(person => person.LastName, columnName: nameof(Person.LastName))
+                .AddMapping(person => person.FirstName)
+                .AddMapping(person => person.LastName)
                 .AddMapping(person => person.DateOfBirth, columnName: "Birthday")
                 .Build();
             // 3 properties/parameters * 700 entities = 2,100 properties/parameters, wich is greater than MaxAllowedSqlParametersCount (2100-1)

--- a/src/MsSqlHelpers/MapperBuilder.cs
+++ b/src/MsSqlHelpers/MapperBuilder.cs
@@ -26,6 +26,12 @@ namespace MsSqlHelpers
             return this;
         }
 
+        /// <summary>
+        /// Use this method overload if your table column's name is different from your property's name
+        /// </summary>
+        /// <param name="propertyName"></param>
+        /// <param name="columnName"></param>
+        /// <returns></returns>
         public MapperBuilder<T> AddMapping(string propertyName, string columnName)
         {
             _mapper.Mappings.Add(propertyName, columnName);
@@ -33,6 +39,25 @@ namespace MsSqlHelpers
             return this;
         }
 
+        /// <summary>
+        /// Use this method overload if your table column's name is the same as your property's name
+        /// </summary>
+        /// <param name="propertyColumnName"></param>
+        /// <returns></returns>
+        public MapperBuilder<T> AddMapping(string propertyColumnName)
+        {
+            _mapper.Mappings.Add(propertyColumnName, propertyColumnName);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Use this method overload if your table column's name is different from your property's name
+        /// </summary>
+        /// <typeparam name="TProperty"></typeparam>
+        /// <param name="propertyLambda"></param>
+        /// <param name="columnName"></param>
+        /// <returns></returns>
         public MapperBuilder<T> AddMapping<TProperty>(
             Expression<Func<T, TProperty>> propertyLambda, string columnName)
         {
@@ -41,6 +66,24 @@ namespace MsSqlHelpers
             var propertyInfo = memberExpression.Member as PropertyInfo ??
                 throw new ArgumentException($"{nameof(memberExpression)}.Member must be a PropertyInfo.", nameof(propertyLambda));
             _mapper.Mappings.Add(propertyInfo.Name, columnName);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Use this method overload if your table column's name is the same as your property's name
+        /// </summary>
+        /// <typeparam name="TProperty"></typeparam>
+        /// <param name="propertyLambda"></param>
+        /// <returns></returns>
+        public MapperBuilder<T> AddMapping<TProperty>(
+            Expression<Func<T, TProperty>> propertyLambda)
+        {
+            var memberExpression = propertyLambda.Body as MemberExpression ??
+                throw new ArgumentException($"{nameof(propertyLambda)}.Body must be a MemberExpression.", nameof(propertyLambda));
+            var propertyInfo = memberExpression.Member as PropertyInfo ??
+                throw new ArgumentException($"{nameof(memberExpression)}.Member must be a PropertyInfo.", nameof(propertyLambda));
+            _mapper.Mappings.Add(propertyInfo.Name, propertyInfo.Name);
 
             return this;
         }

--- a/src/MsSqlHelpers/MsSqlHelpers.csproj
+++ b/src/MsSqlHelpers/MsSqlHelpers.csproj
@@ -3,17 +3,16 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Authors>Alessandro Cagliostro Goncalves Neves</Authors>
     <Company>Alessandro Cagliostro Goncalves Neves</Company>
     <Description>MsSqlHelpers is a library to improve MS SQL Server common development tasks, like generating parametrized bulk inserts to be used with ADO.NET, Entity Framework and Dapper, and more (in a near future).</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/alecgn/mssql-helpers</PackageProjectUrl>
     <RepositoryUrl>https://github.com/alecgn/mssql-helpers</RepositoryUrl>
-    <AssemblyVersion>1.3.1</AssemblyVersion>
-    <FileVersion>1.3.1</FileVersion>
-    <PackageReleaseNotes>- Added parameter to allow identity insert (default off).
-- Fixed "allowIdentityInsert" parameter not being passed to inner methods.</PackageReleaseNotes>
+    <AssemblyVersion>1.3.2</AssemblyVersion>
+    <FileVersion>1.3.2</FileVersion>
+    <PackageReleaseNotes>- Added method overloads to omit parameter "columnName" when the table column's name is the same as property's name.</PackageReleaseNotes>
     <Copyright>Alessandro Cagliostro Goncalves Neves, 2021</Copyright>
     <PackageIcon>mssql-helpers-icon.png</PackageIcon>
     <PackageTags>ms sql server database dapper entity framework ado bulk insert net c# c-sharp</PackageTags>


### PR DESCRIPTION
Added method overloads to omit param "columnName" when table column's name is the same as property's name.